### PR TITLE
Ignore IDL Files for Repository Language Detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pro linguist-vendored


### PR DESCRIPTION
Added a gitattributes file that should make the github language detection ignore the idl files