### PR TITLE
Add Sphinx docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/generated/
 
 # PyBuilder
 .pybuilder/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,28 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.13"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - docs

--- a/KN1DPy/create_shifted_maxwellian.py
+++ b/KN1DPy/create_shifted_maxwellian.py
@@ -1,43 +1,56 @@
+from numpy.typing import NDArray, ArrayLike
 import numpy as np
 
 from .make_dvr_dvx import VSpace_Differentials
 from .common import constants as CONST
 
-def compensate_distribution(f_slice, vdiff, vr, vx, vth, target_vx, target_energy, nb = 1, assume_pos = True):
-    '''
+
+def compensate_distribution(
+    f_slice: NDArray,
+    vdiff: VSpace_Differentials,
+    vr: NDArray,
+    vx: NDArray,
+    vth: NDArray,
+    target_vx: NDArray,
+    target_energy: NDArray,
+    nb: ArrayLike = 1,
+    assume_pos: bool = True,
+) -> tuple[NDArray, float]:
+    """
     Custom Compensation scheme to give a distribution desired moments. Performs on one slice of the distribution.
 
     Parameters
     ----------
-        f_slice : ndarray
-            Slice of distribution fucntion
-        vdiff : VSpace_Differentials
-            Velocity space differentials for distribution function
-        vr : ndarray
-            Radial Velocities
-        vx : ndarray
-            Axial Velocities
-        vth : ndarray
-            Thermal Velocities
-        target_vx : ndarray
-            Target vx moment for distribution slice
-        target_energy : ndarray
-            Target energy moment for distribution slice
-        nb : ndarray
-            Density factor (Used in interp_fvrvxx)
-        assume_pos : bool
-            Sets whether the function assumes the distribution is positive
-            Defaults to (True)
+    f_slice :
+        Slice of distribution fucntion
+    vdiff :
+        Velocity space differentials for distribution function
+    vr :
+        Radial Velocities
+    vx :
+        Axial Velocities
+    vth :
+        Thermal Velocities
+    target_vx :
+        Target vx moment for distribution slice
+    target_energy :
+        Target energy moment for distribution slice
+    nb :
+        Density factor (Used in interp_fvrvxx)
+    assume_pos :
+        Sets whether the function assumes the distribution is positive
+        Defaults to (True)
 
     Returns
     -------
-        f_slice : ndarray
-            Adjusted distribution function
-        s : float
-            Correction scalar (Used in interp_fvrvxx)
-    '''
-    
-    #NOTE Get nb name checked
+    f_slice : ndarray
+        Adjusted distribution function
+    s : float
+        Correction scalar (Used in interp_fvrvxx)
+
+    """
+
+    # NOTE Get nb name checked
 
     vth_diffs = np.zeros((vr.size, vx.size, 2), float)
     vrvx_diffs = np.zeros((vr.size, vx.size, 2), float)
@@ -157,50 +170,52 @@ def compensate_distribution(f_slice, vdiff, vr, vx, vth, target_vx, target_energ
 
 # NOTE Look at PlasmaPy, specifically plasmapy.formulary.distribution.Maxwellian_velocity_2D
 # NOTE Adjust Docstring for accuracy
-def create_shifted_maxwellian(vr,vx,Tmaxwell,vx_shift,mu,mol,Tnorm):
-    '''
-    Creates a shifted maxwellian distrubution with a desired temperature and vx moment
+def create_shifted_maxwellian(vr, vx, Tmaxwell, vx_shift, mu, mol, Tnorm):
+    """Creates a shifted maxwellian distrubution with a desired temperature and vx moment
 
     Parameters
     ----------
-        vr : ndarray
-            radial velocities
-        vx : ndarray
-            axial velocities
-        Tmaxwell : ndarray
-            Desired temperature moments, (eV)
-        vx_shift : ndarray
-            Desired vx moments, (m s^-1)
-        mu : int
-            1=hydrogen, 2=deuterium
-        mol : int
-            1=atom, 2=diatomic molecule
-        Tnorm : ndarray
-            Average Temperatures
-            
+    vr : ndarray
+        radial velocities
+    vx : ndarray
+        axial velocities
+    Tmaxwell : ndarray
+        Desired temperature moments, (eV)
+    vx_shift : ndarray
+        Desired vx moments, (m s^-1)
+    mu : int
+        1=hydrogen, 2=deuterium
+    mol : int
+        1=atom, 2=diatomic molecule
+    Tnorm : ndarray
+        Average Temperatures
+
     Returns
     -------
-        Maxwell : ndarray
-           3D array of shape (len(vr), len(vx), len(vx_shift)) 
-           Shifted Maxwellian distribution function having numerically 
-           evaluated vx moment close to Vx_shift and temperature close to Tmaxwell
+    Maxwell : ndarray
+        3D array of shape ``(len(vr), len(vx), len(vx_shift))``.
+        Shifted Maxwellian distribution function having numerically
+        evaluated vx moment close to Vx_shift and temperature close to Tmaxwell
 
     Notes
-    -------
-        One might think that Maxwell could be simply computed by a direct evaluation of the EXP function:
+    -----
+    One might think that Maxwell could be simply computed by a direct evaluation
+    of the EXP function::
 
-            for i=0,nvr-1 do begin
-                arg=-(vr(i)^2+(vx-Vx_shift/vth)^2) * mol*Tnorm/Tmaxwell
-                Maxwell(i,*,k)=exp(arg > (-80))
-            endfor
+        for i in range(nvr-1):
+            arg = -(vr(i)^2+(vx-Vx_shift/vth)^2) * mol*Tnorm/Tmaxwell
+            Maxwell[i,:,k] = exp(arg > (-80))
 
-        But owing to the discrete velocity space bins, this method does not necessarily lead to a digital representation 
-        of a shifted Maxwellian (Maxwell) that when integrated numerically has the desired vx moment of Vx_shift
-        and temperature, Tmaxwell.
+    But owing to the discrete velocity space bins, this method does not
+    necessarily lead to a digital representation of a shifted Maxwellian
+    (Maxwell) that when integrated numerically has the desired vx moment of
+    Vx_shift and temperature, Tmaxwell.
 
-        In order to insure that Maxwell has the desired vx and T moments when evaluated numerically, a compensation
-        scheme is employed - similar to that used in Interp_fVrVxX. See compensate_distribution()
-    '''
+    In order to insure that Maxwell has the desired vx and T moments when
+    evaluated numerically, a compensation scheme is employed - similar to that
+    used in Interp_fVrVxX. See `compensate_distribution()`
+
+    """
 
     maxwell = np.zeros((vr.size, vx.size, vx_shift.size), float)
     vth = np.sqrt(2*CONST.Q*Tnorm / (mu*CONST.H_MASS)) #Thermal Velocity

--- a/KN1DPy/interp_fvrvxx.py
+++ b/KN1DPy/interp_fvrvxx.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import numpy as np
 from warnings import warn
 
@@ -13,17 +14,17 @@ def _get_interpolation_bounds(a, b, a_name="a", b_name="b"):
 
     Parameters
     ----------
-        a : ndarray
-            array that determines bounds of b
-        b : ndarray
-            array being bounded
-        a_name, b_name : str (optional)
-            variable names for exception message
+    a : ndarray
+        array that determines bounds of b
+    b : ndarray
+        array being bounded
+    a_name, b_name : str (optional)
+        variable names for exception message
 
     Returns
     -------
-        tuple : (int, int)
-            start, end of the interpolation range
+    tuple : (int, int)
+        start, end of the interpolation range
     
     Raises
     -------
@@ -43,24 +44,24 @@ def _test_bounds(fb, test_bound : Bound, var_len, test_axis, iter_bound1 : Bound
 
     Parameters
     ----------
-        fb : ndarray
-            3D array, distribution function
-        test_bound : Bound
-            boundary being tested
-        var_len : int
-            Length of the variable distribution whose bound is being tested
-        test_axis : int
-            Determines axis for slicing fb, 0, 1, or 2
-        iter_bound1, iter_bound2 : Bound
-            Boundaries being tested over
-        do_warn : float
-            Acceptable truncation level
-        var_name : str (optional)
-            variable name for warning message
+    fb : ndarray
+        3D array, distribution function
+    test_bound : Bound
+        boundary being tested
+    var_len : int
+        Length of the variable distribution whose bound is being tested
+    test_axis : int
+        Determines axis for slicing fb, 0, 1, or 2
+    iter_bound1, iter_bound2 : Bound
+        Boundaries being tested over
+    do_warn : float
+        Acceptable truncation level
+    var_name : str (optional)
+        variable name for warning message
     
     Issues
     -------
-        Warning if 0 found at boundary edge
+    Warning if 0 found at boundary edge
     '''
 
     big = np.max(fb)
@@ -87,35 +88,35 @@ def _test_bounds(fb, test_bound : Bound, var_len, test_axis, iter_bound1 : Bound
             warn(f"Non-zero value of fb detected at max({var_name}) boundary")
 
 
-def interp_fvrvxx(fa: np.ndarray, mesh_a : KineticMesh, mesh_b : KineticMesh, do_warn=None, debug=False, correct=1):
+def interp_fvrvxx(fa: np.ndarray, mesh_a : KineticMesh, mesh_b : KineticMesh, do_warn: Optional[float] =None, debug: bool=False, correct=1):
     '''
     Interpolates distribution functions used by kinetic neutral procedures
 
     Parameters
     ----------
-        fa : ndarray
-            Input distribution function, 3D array of shape (vra, vxa, xa)
-        mesh_a : KineticMesh
-            Mesh information for input distribution
-        mesh_b : KineticMesh
-            Mesh information for desired output distribution
-        do_warn : float or None (optional)
-            Accebtable truncation level. If None, warnings are not generated
-                For interpolations outside the phase space set by
-                (Vra, Vxa, Xa), the values of fb are set to zero.
-                This may not be acceptable. A test is performed on
-                fb at the boundaries. If fb at the boundaries is greater
-                than do_warn times the maximum value of fb,
-                a warning message is generated.
-        debug : bool
-            If True, generate debug statements
+    fa :
+        Input distribution function, 3D array of shape (vra, vxa, xa)
+    mesh_a :
+        Mesh information for input distribution
+    mesh_b :
+        Mesh information for desired output distribution
+    do_warn :
+        Accebtable truncation level. If None, warnings are not generated.
+        For interpolations outside the phase space set by
+        (Vra, Vxa, Xa), the values of fb are set to zero.
+        This may not be acceptable. A test is performed on
+        fb at the boundaries. If fb at the boundaries is greater
+        than do_warn times the maximum value of fb,
+        a warning message is generated.
+    debug : bool
+        If True, generate debug statements
             
     Returns
     -------
-        fb : ndarray
-            Interpolated distribution function, scaled if necessary to make its 
-            digital integral over all velocity space equal to that of fa
-            3D array of of shape (vrb, vxb, xb)
+    fb : ndarray
+        Interpolated distribution function, scaled if necessary to make its
+        digital integral over all velocity space equal to that of fa
+        3D array of of shape (vrb, vxb, xb)
     '''
 
     prompt = 'INTERP_FVRVXX => '

--- a/KN1DPy/kinetic_h.py
+++ b/KN1DPy/kinetic_h.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from dataclasses import dataclass
 import numpy as np
 from numpy.typing import NDArray
@@ -59,25 +60,39 @@ class CollisionType():
 
 @dataclass
 class KHResults():
-    '''
-    Variables for results of KineticH.run_procedure()
-    See run_procedure for more detail on individual variables
-    '''
+    """
+    Variables for results of `KineticH.run_procedure()`
+    """
     fH: NDArray
+    """3D array, atomic distribution function."""
     nH: NDArray
+    """Neutral atom density profile (m^-3)."""
     GammaxH: NDArray
+    """Neutral flux profile (m^-2 s^-1)"""
     VxH: NDArray
+    """Neutral velocity profile (m s^-1)"""
     pH: NDArray
+    """Neutral pressure (eV m^-2)"""
     TH: NDArray
+    """Neutral temperature profile (eV)"""
     qxH: NDArray
+    """Neutral random heat flux profile (watts m^-2)"""
     qxH_total: NDArray
+    """Total neutral heat flux profile (watts m^-2)"""
     NetHSource: NDArray
+    """Net H0 source (m^-3 s^-1)"""
     Sion: NDArray
+    """H ionization rate (m^-3 s^-1)"""
     QH: NDArray
+    """Rate of net thermal energy transfer into neutral atoms (watts m^-3)"""
     RxH: NDArray
+    """Rate of x momentum transfer to neutral atoms (N m^-2)"""
     QH_total: NDArray
+    """Net rate of total energy transfer into neutral atoms (watts m^-3)"""
     AlbedoH: float
+    """Ratio of atomic particle flux with Vx < 0 divided by particle flux with Vx > 0 at x=0"""
     SideWallH: NDArray
+    """Atomic sink rate from interation with 'side walls' (m^-3 s^-1)"""
 
 
 class KineticH():
@@ -124,44 +139,44 @@ class KineticH():
     prompt = 'Kinetic_H => '
 
 
-    def __init__(self, mesh: KineticMesh, mu: int, vxi: NDArray, fHBC: NDArray, GammaxHBC: float, jh: Johnson_Hinnov = None,
+    def __init__(self, mesh: KineticMesh, mu: int, vxi: NDArray, fHBC: NDArray, GammaxHBC: float, jh: Optional[Johnson_Hinnov] = None,
                  recomb: bool = True, ni_correct: bool = False, truncate: float = 1e-4, max_gen: int = 100,
                  compute_errors: bool = False, debrief: int = 0, debug: int = 0, config_path: str = './config.json'):
         '''
         Parameters
         ----------
-            mesh : KineticMesh
-                Mesh data for h kinetic procedure, must be of type 'h'
-                Includes coordinate data and temperature/density profiles
-            mu : int
-                1=hydrogen, 2=deuterium
-            vxi : ndarray
-                flow speed profile (m/s)
-            fHBC : ndarray
-                2D array, input boundary condition. Specifies shape of atom velocity distribution (fH) at x=0
-            GammaxHBC : float
-                Desired neutral atom flux density at x=0 (m^-2 s^-1)
-            jh_coeffs : JH_Coef, defualt=None
-                Common blocks used to pass data for JH methods
-            recomb : bool, default=True
-                If true, includes recombination as a source of atomic neutrals in the algorithm
-            ni_correct : bool, default=False
-                If true, Corrects hydrogen ion density according to quasineutrality: ni=ne-nHp
-            truncate : float, default=1.0e-4
-                Convergence threshold for generations
-            max_gen : int, default=50
-                Max number of generations
-            compute_errors : bool, default=False
-                If true, compute error estimates
-            debug : int, default=0
-                - 0=do not execute debug code
-                - 1=summary debug
-                - 2=detail debug
-                - 3=very detailed debug
-            debrief : int, default=0
-                - 0=do not print
-                - 1=print summary information
-                - 2=print detailed information
+        mesh :
+            Mesh data for h kinetic procedure, must be of type 'h'
+            Includes coordinate data and temperature/density profiles
+        mu :
+            1=hydrogen, 2=deuterium
+        vxi :
+            flow speed profile (m/s)
+        fHBC :
+            2D array, input boundary condition. Specifies shape of atom velocity distribution (fH) at x=0
+        GammaxHBC :
+            Desired neutral atom flux density at x=0 (m^-2 s^-1)
+        jh :
+            Common blocks used to pass data for JH methods
+        recomb :
+            If true, includes recombination as a source of atomic neutrals in the algorithm
+        ni_correct :
+            If true, Corrects hydrogen ion density according to quasineutrality: ni=ne-nHp
+        truncate :
+            Convergence threshold for generations
+        max_gen :
+            Max number of generations
+        compute_errors :
+            If true, compute error estimates
+        debug :
+            - 0=do not execute debug code
+            - 1=summary debug
+            - 2=detail debug
+            - 3=very detailed debug
+        debrief :
+            - 0=do not print
+            - 1=print summary information
+            - 2=print detailed information
         '''
 
         # --- Settings ---
@@ -264,51 +279,16 @@ class KineticH():
 
         Parameters
         ----------
-            fH2 : ndarray, default=None
-                3D array, molecular distribution function. If None, H-H2 collisions are not computed
-            fSH : ndarray, defualt=None
-                Source velocity distribution function. If None, zero array is used
-            fH : ndarray, default=None
-                3D array, atomic distribution function. If None, zero array is used
-            nHP : ndarray, defualt=None
-                Molecular ion density profile (m^-3). If None, zero array is used
-            THP : ndarray, defualt=None
-                Molecular ion temperature profile (m^-3). If None, array of 3.0 used
-
-        Returns
-        -------
-        KHResults
-
-            fH : ndarray
-                3D array, atomic distribution function.
-            nH : ndarray, defualt=None
-                Neutral atom density profile (m^-3).
-            GammaxH : ndarray
-                Neutral flux profile (m^-2 s^-1)
-            VxH : ndarray
-                Neutral velocity profile (m s^-1)
-            pH : ndarray
-                Neutral pressure (eV m^-2)
-            TH : ndarray
-                Neutral temperature profile (eV)
-            qxH : ndarray
-                Neutral random heat flux profile (watts m^-2)
-            qxH_total : ndarray
-                Total neutral heat flux profile (watts m^-2)
-            NetHSource : ndarray
-                Net H0 source (m^-3 s^-1)
-            Sion : ndarray
-                H ionization rate (m^-3 s^-1)
-            QH : ndarray
-                Rate of net thermal energy transfer into neutral atoms (watts m^-3)
-            RxH : ndarray
-                Rate of x momentum transfer to neutral atoms (N m^-2)
-            QH_total : ndarray
-                Net rate of total energy transfer into neutral atoms (watts m^-3)
-            AlbedoH : float
-                Ratio of atomic particle flux with Vx < 0 divided by particle flux with Vx > 0 at x=0
-            SideWallH : ndarray
-                Atomic sink rate from interation with 'side walls' (m^-3 s^-1)
+        fH2 : ndarray
+            3D array, molecular distribution function. If None, H-H2 collisions are not computed
+        fSH : ndarray
+            Source velocity distribution function. If None, zero array is used
+        fH : ndarray, default=None
+            3D array, atomic distribution function. If None, zero array is used
+        nHP : ndarray
+            Molecular ion density profile (m^-3). If None, zero array is used
+        THP : ndarray
+            Molecular ion temperature profile (m^-3). If None, array of 3.0 used
         '''
 
         nvr, nvx, nx = self.nvr, self.nvx, self.nx

--- a/KN1DPy/kinetic_h2.py
+++ b/KN1DPy/kinetic_h2.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from dataclasses import dataclass
 import numpy as np
 from numpy.typing import NDArray
@@ -144,42 +145,42 @@ class KineticH2():
         '''
         Parameters
         ----------
-            mesh : KineticMesh
-                Mesh data for h2 kinetic procedure, must be of type 'h2'
-                Includes coordinate data and temperature/density profiles
-            mu : int
-                1=hydrogen, 2=deuterium
-            vxi : ndarray
-                flow speed profile (m/s)
-            fH2BC : ndarray
-                2D array, input boundary condition. Specifies shape of molecule velocity distribution (fH2) at x=0
-            GammaxH2BC : float
-                Desired neutral molecule flux density at x=0 (m^-2 s^-1)
-            NuLoss : ndarray
-                Characteristic molecular ion loss frequency profile (1/s)
-            SH2_inital : ndarray, defualt=None
-                Initial guess for source profile of wall-temperature H2 molecules (m^-3 s^-1). If None, zero array is used
-            sawada : bool, default=False
-                If false, disable Sawada correction
-            compute_h_source : bool, default=False
-                If true, compute fSH, SH, SP, and SHP
-            ni_correct : bool, default=False
-                If true, Corrects hydrogen ion density according to quasineutrality: ni=ne-nHp
-            truncate : float, default=1.0e-4
-                Convergence threshold for generations
-            max_gen : int, default=50
-                Max number of generations
-            compute_errors : bool, default=False
-                If true, compute error estimates
-            debrief : int, default=0
-                - 0=do not print
-                - 1=print summary information
-                - 2=print detailed information
-            debug : int, default=0
-                - 0=do not execute debug code
-                - 1=summary debug
-                - 2=detail debug
-                - 3=very detailed debug
+        mesh :
+            Mesh data for h2 kinetic procedure, must be of type 'h2'
+            Includes coordinate data and temperature/density profiles
+        mu :
+            1=hydrogen, 2=deuterium
+        vxi :
+            flow speed profile (m/s)
+        fH2BC :
+            2D array, input boundary condition. Specifies shape of molecule velocity distribution (fH2) at x=0
+        GammaxH2BC :
+            Desired neutral molecule flux density at x=0 (m^-2 s^-1)
+        NuLoss :
+            Characteristic molecular ion loss frequency profile (1/s)
+        SH2_initial :
+            Initial guess for source profile of wall-temperature H2 molecules (m^-3 s^-1). If None, zero array is used
+        sawada :
+            If false, disable Sawada correction
+        compute_h_source :
+            If true, compute fSH, SH, SP, and SHP
+        ni_correct :
+            If true, Corrects hydrogen ion density according to quasineutrality: ni=ne-nHp
+        truncate :
+            Convergence threshold for generations
+        max_gen :
+            Max number of generations
+        compute_errors :
+            If true, compute error estimates
+        debrief :
+            - 0=do not print
+            - 1=print summary information
+            - 2=print detailed information
+        debug :
+            - 0=do not execute debug code
+            - 1=summary debug
+            - 2=detail debug
+            - 3=very detailed debug
         '''
 
         # --- Settings ---
@@ -274,23 +275,23 @@ class KineticH2():
         return
 
 
-    def run_procedure(self, fH: NDArray = None, SH2: NDArray = None, fH2: NDArray = None, nHP: NDArray = None, THP: NDArray = None) -> KH2Results:
+    def run_procedure(self, fH: Optional[NDArray] = None, SH2: Optional[NDArray] = None, fH2: Optional[NDArray] = None, nHP: Optional[NDArray] = None, THP: Optional[NDArray] = None) -> KH2Results:
         '''
         Solves a 1-D spatial, 2-D velocity kinetic neutral transport 
         problem for molecular hydrogen or deuterium (H2)
 
         Parameters
         ----------
-            fH : ndarray, default=None
-                3D array, atomic distribution function. If None, H-H2 collisions are not computed
-            SH2 : ndarray, defualt=None
-                Source profile of wall-temperature H2 molecules (m^-3 s^-1). If None, zero array is used
-            fH2 : ndarray, defualt=None
-                3D array, molecular distribution function. If None, zero array is used
-            nHP : ndarray, defualt=None
-                Molecular ion density profile (m^-3). If None, zero array is used
-            THP : ndarray, defualt=None
-                Molecular ion temperature profile (m^-3). If None, array of 3.0 used
+        fH :
+            3D array, atomic distribution function. If None, H-H2 collisions are not computed
+        SH2 :
+            Source profile of wall-temperature H2 molecules (m^-3 s^-1). If None, zero array is used
+        fH2 :
+            3D array, molecular distribution function. If None, zero array is used
+        nHP :
+            Molecular ion density profile (m^-3). If None, zero array is used
+        THP :
+            Molecular ion temperature profile (m^-3). If None, array of 3.0 used
             
         Returns
         -------
@@ -298,9 +299,9 @@ class KineticH2():
 
             fH2 : ndarray
                 3D array, molecular distribution function.
-            nHP : ndarray, defualt=None
+            nHP : ndarray
                 Molecular ion density profile (m^-3).
-            THP : ndarray, defualt=None
+            THP : ndarray
                 Molecular ion temperature profile (m^-3).
             nH2 : ndarray
                 Molecular density profile (m^-3)

--- a/KN1DPy/kn1d.py
+++ b/KN1DPy/kn1d.py
@@ -76,40 +76,40 @@ def kn1d(x, xlimiter, xsep, GaugeH2, mu, Ti, Te, n, vxi, LC, PipeDia,
 
     Parameters
     ----------
-        x : ndarray(nx)
-            Cross-field coordinate (meters)
-        xlimiter : float
-            Cross-field coordinate of limiter edge (meters) (for graphic on plots)
-        xsep : float
-            Cross-field coordinate separatrix (meters) (for graphic on plots)
-        GaugeH2	: float
-            Molecular pressure (mtorr)
-        mu : float
-            1=hydrogen, 2=deuterium
-        Ti : ndarray(nx)
-            Ion temperature profile (eV)
-        Te : ndarray(nx)
-            Electron temperature profile (eV)
-        n : ndarray(nx)
-            Density profile (m^-3)
-        vxi	: ndarray(nx)
-            Plasma velocity profile [negative is towards 'wall' (m s^-1)]
-        LC : ndarray(nx)
-            Connection length (surface to surface) along field lines to nearest limiters (meters)
-                Zero values of LC are treated as LC=infinity.
-        PipeDia	: ndarray(nx)
-            Effective pipe diameter (meters)
-                This variable allows collisions with the 'side-walls' to be simulated.
-                If this variable is undefined, then PipeDia set set to zero. Zero values
-                of PipeDia are ignored (i.e., treated as an infinite diameter).
-        truncate : float, default=1.0e-3
-            Convergence threshold for generations
-                fH and fH2 are refined by iteration via routines Kinetic_H2 and Kinetic_H
-                until the maximum change in molecular neutral density (over its profile) normalized to 
-                the maximum value of molecular density is less than this 
-                value in a subsequent iteration.
-        max_gen : int, default=50
-            Maximum number of collision generations to try including before giving up.
+    x : ndarray(nx)
+        Cross-field coordinate (meters)
+    xlimiter : float
+        Cross-field coordinate of limiter edge (meters) (for graphic on plots)
+    xsep : float
+        Cross-field coordinate separatrix (meters) (for graphic on plots)
+    GaugeH2 : float
+        Molecular pressure (mtorr)
+    mu : float
+        1=hydrogen, 2=deuterium
+    Ti : ndarray(nx)
+        Ion temperature profile (eV)
+    Te : ndarray(nx)
+        Electron temperature profile (eV)
+    n : ndarray(nx)
+        Density profile (m^-3)
+    vxi	: ndarray(nx)
+        Plasma velocity profile [negative is towards 'wall' (m s^-1)]
+    LC : ndarray(nx)
+        Connection length (surface to surface) along field lines to nearest limiters (meters)
+            Zero values of LC are treated as LC=infinity.
+    PipeDia : ndarray(nx)
+        Effective pipe diameter (meters)
+            This variable allows collisions with the 'side-walls' to be simulated.
+            If this variable is undefined, then PipeDia set set to zero. Zero values
+            of PipeDia are ignored (i.e., treated as an infinite diameter).
+    truncate : float
+        Convergence threshold for generations
+            fH and fH2 are refined by iteration via routines Kinetic_H2 and Kinetic_H
+            until the maximum change in molecular neutral density (over its profile) normalized to 
+            the maximum value of molecular density is less than this 
+            value in a subsequent iteration.
+    max_gen : int
+        Maximum number of collision generations to try including before giving up.
 
     Returns
     -------

--- a/KN1DPy/kn1d_lite.py
+++ b/KN1DPy/kn1d_lite.py
@@ -1,5 +1,6 @@
+from typing import Optional
 import numpy as np
-from numpy.typing import NDArray
+from numpy.typing import NDArray, ArrayLike
 from scipy import interpolate
 from dataclasses import dataclass
 
@@ -37,9 +38,9 @@ def kn1d_lite(
     incident_n0,
 
     # Simple mode
-    energies_eV=None,
-    velocities_ms=None,
-    fractions=None,
+    energies_eV: Optional[ArrayLike]=None,
+    velocities_ms: Optional[ArrayLike]=None,
+    fractions: Optional[ArrayLike]=None,
 
     # Advanced mode
     fH_BC=None,
@@ -74,47 +75,43 @@ def kn1d_lite(
         Incident neutral density at the boundary (m^-3).  This is the
         *incident* flux only — output nH will be higher due to reflections
         and charge exchange.
-
-    Simple mode (assumes one or more mono-energetic components for incoming neutrals)
-    ---------------------------------------------------
-    energies_eV : array-like, optional
-        Energy of each component in eV.  Default [3.0].
-    velocities_ms : array-like, optional
+    energies_eV :
+        Energy of each component in eV.
+    velocities_ms :
         Speed of each component in m/s.  Overrides energies_eV if given.
-    fractions : array-like, optional
+    fractions :
         Fraction of incident_n0 in each component (must sum to 1).
-        Default [1.0].
 
-    # NOTE
-    The default is that all the neutrals enter with 3eV. 
-    An input of energies_eV=[3, 10] and fractions=[0.7, 0.3] would mean that 70% of the incident neutrals have 3eV and 30% have 10eV.  
-    If velocities_ms is given instead, those speeds are used directly (and energies_eV is ignored).
+        .. note::
+            The default is that all the neutrals enter with 3eV. An input of
+            ``energies_eV=[3, 10]`` and ``fractions=[0.7, 0.3]`` would mean that 70%
+            of the incident neutrals have 3eV and 30% have 10eV. If velocities_ms is
+            given instead, those speeds are used directly (and energies_eV is
+            ignored).
 
-    Advanced mode (arbitrary distribution function)
-    ------------------------------------------------
     fH_BC : ndarray(nvr, nvx), optional
-        Boundary distribution function with arbitrary normalisation.
-        Scaled internally so that integral = incident_n0.  Negative-vx
-        entries are zeroed out before use.
+        Boundary distribution function with arbitrary normalisation.  Scaled
+        internally so that ``integral = incident_n0``. Negative-vx entries are
+        zeroed out before use.
 
-    # NOTE
-    The simple mode should suffice for most users. Only use advanced if you want to explore the
-    shape of the distribution function on the neutral penetration.
+        .. note::
+            This is an advanced parameter that allows arbitrary distribution
+            functions, and should only be used if you want to explore the shape
+            of the distribution function on the neutral penetration.
 
-    Other
-    -----
+            The simpler mode, using just
+            ``energies_eV``/``velocities_ms``/``fractions``, which assumes one
+            or more mono-energetic components for incoming neutrals, should be
+            sufficient for most users.
+
     truncate : float
-        Convergence threshold.  Default 1e-3.
+        Convergence threshold.
     max_gen : int
-        Maximum collision generations.  Default 50.
+        Maximum collision generations.
     compute_errors : bool
     debrief : bool
     debug : bool
     config_path : str
-
-    Returns
-    -------
-    KN1DLiteResults
     '''
 
     prompt = 'KN1D_lite => '

--- a/KN1DPy/rates/janev/sigma_cx_h0.py
+++ b/KN1DPy/rates/janev/sigma_cx_h0.py
@@ -1,31 +1,34 @@
+from numpy.typing import ArrayLike
 import numpy as np
 
 from ...utils import poly
 
-def sigma_cx_h0(E, freeman=False):
+def sigma_cx_h0(E: ArrayLike, freeman: bool=False):
     '''
-    Computes charge exchange cross section for atomic hydrogen. Data are taken either from the polynomial fit in
-        Janev, "Elementary Processes in Hydrogen-Helium Plasmas", Springer-Verlag, 1987, p.250.
-    or from Freeman and Jone's analytic fit tabulated in 
-        Freeman, E.L., Jones, E.M., "Atomic Collision Processes in Plasma Physics
-        Experiments", UKAEA Report No. CLM-R137 (Culham Laboratory, Abington, England 1974)
+    Computes charge exchange cross section for atomic hydrogen.
+
+    Data are taken either from the polynomial fit in
+    *Janev, "Elementary Processes in Hydrogen-Helium Plasmas", Springer-Verlag, 1987, p.250.*
+    or from Freeman and Jone's analytic fit tabulated in
+    *Freeman, E.L., Jones, E.M., "Atomic Collision Processes in Plasma Physics
+    Experiments", UKAEA Report No. CLM-R137 (Culham Laboratory, Abington, England 1974)*
 
     Parameters
     ----------
-        E : ndarray or float
-            energy of proton corresponding to the relative velocity between proton and hydrogen atom (eV)
-        freeman: bool, default=false
-            if true, then return CX based on Freeman and Jones' analytic fit in
-            Freeman, E.L., Jones, E.M., "Atomic Collision Processes in Plasma Physics
-            Experiments", UKAEA Report No. CLM-R137 (Culham Laboratory, Abington, England 1974).
-            Otherwise, return CX based on polynomial fit in
-		    Janev, "Elementary Processes in Hydrogen-Helium Plasmas", 
-	        Springer-Verlag, 1987, p.250, other
+    E :
+        energy of proton corresponding to the relative velocity between proton and hydrogen atom (eV)
+    freeman:
+        if true, then return CX based on Freeman and Jones' analytic fit in
+        *Freeman, E.L., Jones, E.M., "Atomic Collision Processes in Plasma Physics
+        Experiments", UKAEA Report No. CLM-R137 (Culham Laboratory, Abington, England 1974)*.
+        Otherwise, return CX based on polynomial fit in
+        *Janev, "Elementary Processes in Hydrogen-Helium Plasmas",
+        Springer-Verlag, 1987, p.250, other*
 
     Returns
     -------
-        ndarray
-            sigma_CX for 0.1 < E < 2e4 (m^-2)
+    ndarray
+        sigma_CX for 0.1 < E < 2e4 (m^-2)
     '''
                 
     E = np.asarray(E)

--- a/KN1DPy/rates/janev/sigma_el_h_h.py
+++ b/KN1DPy/rates/janev/sigma_el_h_h.py
@@ -1,8 +1,9 @@
+from numpy.typing import ArrayLike
 import numpy as np 
 
 from ...utils import poly
 
-def sigma_el_h_h(E, vis = False):
+def sigma_el_h_h(E: ArrayLike, vis: bool = False):
     '''
     Computes momentum transfer cross section for elastic collisions of H onto H
     for specified energy of H. Data are taken from 
@@ -14,16 +15,16 @@ def sigma_el_h_h(E, vis = False):
 
     Parameters
     ----------
-    E : ndarray or float
+    E :
         energy of H atom (target H atom is at rest)
-    vis : bool, defaul=False
+    vis :
         if true, then return viscosity cross section instead of momentum transfer cross section 
     
     Returns
     -------
-        ndarray
-            Sigma for 0.03 < E < 1e4. For E outside this range, 
-            the value of Sigma at the 0.03 or 1e4 eV boundary is returned. (m^-2)
+    ndarray
+        Sigma for 0.03 < E < 1e4. For E outside this range, 
+        the value of Sigma at the 0.03 or 1e4 eV boundary is returned. (m^-2)
     '''
 
     E = np.asarray(E, dtype=float)

--- a/KN1DPy/rates/janev/sigma_el_hh_hh.py
+++ b/KN1DPy/rates/janev/sigma_el_hh_hh.py
@@ -1,8 +1,9 @@
+from numpy.typing import ArrayLike
 import numpy as np
 
 from ...utils import poly
 
-def sigma_el_hh_hh(E, vis = False):
+def sigma_el_hh_hh(E: ArrayLike, vis: bool = False):
     '''
     Computes momentum transfer cross section for elastic collisions of H2 onto H2 
     for specified energy of H2. Data are taken from 
@@ -14,16 +15,16 @@ def sigma_el_hh_hh(E, vis = False):
 
     Parameters
     ----------
-    E : ndarray or float
+    E :
         energy of H2 molecule (target H2 molecule is at rest)
-    vis : bool, defaul=False
+    vis :
         if true, then return viscosity cross section instead of momentum transfer cross section 
     
     Returns
     -------
-        ndarray
-            Sigma for 0.03 < E < 1e4. For E outside this range, 
-            the value of Sigma at the 0.03 or 1e4 eV boundary is returned. (m^-2)
+    ndarray
+        Sigma for 0.03 < E < 1e4. For E outside this range, 
+        the value of Sigma at the 0.03 or 1e4 eV boundary is returned. (m^-2)
     '''
     E = np.asarray(E, dtype=float)
 

--- a/KN1DPy/rates/johnson_hinnov/johnson_hinnov.py
+++ b/KN1DPy/rates/johnson_hinnov/johnson_hinnov.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-from numpy.typing import NDArray
+from numpy.typing import NDArray, ArrayLike
 from scipy import interpolate
 
 from ...utils import get_local_directory, bs2dr
@@ -44,7 +44,7 @@ class Johnson_Hinnov():
 
         Parameters
         ----------
-            create : bool, default = False
+            create : bool
                 If set, regenerate coefficients
                 NOTE This feature is currently not working, use file in github
         '''
@@ -72,16 +72,16 @@ class Johnson_Hinnov():
 
         Parameters
         ----------
-            Density	: ndarray
+            Density :
                 electron density (=hydrogen ion density) (m^-3)
-            Te : ndarray
+            Te :
                 electron temperature (eV
             Ion	: int
                 - 0=return "recombination" coeffcient, r0(p)
                 - 1=return "ionization" coeffcient, r1(p)
-            p : int
+            p :
                 hydrogen energy level, p=1 is ground state 
-            no_null : bool, default=False
+            no_null :
                 if true, then rather than generate a NULL value when Density and Te
                 are outside the data range, compute the rate based on the min or max
                 data range values.
@@ -236,16 +236,16 @@ class Johnson_Hinnov():
         
         Parameters
         ----------
-         	Density : ndarray
-                electron density (=hydrogen ion density) (m^-3)
-         	Te : ndarray
-                electron temperature (eV)
-         	N0 : ndarray
-                ground state neutral density (m^-3)
-        	no_null : bool, default=false
-                if true, then rather than generate a NULL value when Density and Te
-                are not null but still outside the data range, compute the rate based on the min or max
-        		data range values.
+        Density :
+             electron density (=hydrogen ion density) (m^-3)
+        Te :
+             electron temperature (eV)
+        N0 :
+             ground state neutral density (m^-3)
+        no_null :
+             if true, then rather than generate a NULL value when Density and Te
+             are not null but still outside the data range, compute the rate based on the min or max
+             data range values.
         '''
         
         # From Johnson-Hinnov, eq (11):
@@ -269,7 +269,7 @@ class Johnson_Hinnov():
         return result
 
 
-    def balmer_alpha(self, Density : NDArray, Te : NDArray, N0 : NDArray, photons = 0, no_null = 0) -> NDArray:
+    def balmer_alpha(self, Density : NDArray, Te : NDArray, N0 : NDArray, photons: ArrayLike = 0, no_null: bool = False) -> NDArray:
         '''
         Computes Balmer-alpha emissivity (watts m^-3) given the local
         electron density, electron temperature, and ground-state
@@ -284,16 +284,16 @@ class Johnson_Hinnov():
         
         Parameters
         ----------
-            Density : ndarray
-                electron density (=hydrogen ion density) (m^-3)
-            Te : ndarray
-                electron temperature (eV
-            N0 : ndarray
-                ground state neutral density (m^-3)
-            No_Null : bool, default=false
-                if set, then rather than generate a NULL value when Density and Te
-                are not null but still outside the data range, compute the rate based on the min or max
-                data range values.
+        Density :
+            electron density (=hydrogen ion density) (m^-3)
+        Te :
+            electron temperature (eV
+        N0 :
+            ground state neutral density (m^-3)
+        No_Null :
+            if set, then rather than generate a NULL value when Density and Te
+            are not null but still outside the data range, compute the rate based on the min or max
+            data range values.
         '''
 
         # From Johnson-Hinnov, eq (11):

--- a/KN1DPy/utils.py
+++ b/KN1DPy/utils.py
@@ -5,7 +5,7 @@ import json
 from typing import Any
 import os
 
-from numpy.typing import NDArray
+from numpy.typing import NDArray, ArrayLike
 import numpy as np
 from scipy import interpolate
 from scipy.io import readsav
@@ -74,20 +74,20 @@ class Bound:
 
 # --- Polynomials ---
 
-def poly(x, c):
+def poly(x: ArrayLike, c: ArrayLike):
     '''
     Evaluate a polynomial at one or more points
 
     Parameters
     ----------
-        x : float or ndarray
+        x :
             Variable/s to evaluate the polynomial at
-        c : ndarray
+        c :
             array of polynomial coefficients
             
     Returns
     -------
-        y : float or ndarray
+        y : float or NDArray
             Value of the polynomial evaluated at x, array of values if x is an array
     '''
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/_templates/custom-class-template.rst
+++ b/docs/_templates/custom-class-template.rst
@@ -1,0 +1,32 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+   {% block methods %}
+   .. automethod:: __init__
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/_templates/custom-module-template.rst
+++ b/docs/_templates/custom-module-template.rst
@@ -1,0 +1,66 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :toctree:
+      :template: custom-class-template.rst
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :template: custom-module-template.rst
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,10 @@
+===============
+ API Reference
+===============
+
+.. autosummary::
+   :toctree: generated
+   :template: custom-module-template.rst
+   :recursive:
+
+   KN1DPy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx_autodoc_typehints",
+    "myst_parser",
 ]
 
 templates_path = ["_templates"]
@@ -39,6 +40,10 @@ numfig = True
 autodoc_type_aliases = {
     "NDArray": "numpy.typing.NDArray",
     "ArrayLike": "numpy.typing.ArrayLike",
+}
+
+napoleon_type_aliases = {
+    "ndarray": "numpy.typing.NDArray",
 }
 
 autodoc_default_options = {"ignore-module-all": True}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,76 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "KN1D"
+copyright = "2026, Jamie Dunsmore"
+author = "Jamie Dunsmore"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.coverage",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx_autodoc_typehints",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# Numpy-doc config
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
+napoleon_attr_annotations = True
+napoleon_preprocess_types = True
+
+# Enable numbered references
+numfig = True
+
+autodoc_type_aliases = {
+    "NDArray": "numpy.typing.NDArray",
+    "ArrayLike": "numpy.typing.ArrayLike",
+}
+
+autodoc_default_options = {"ignore-module-all": True}
+autodoc_typehints = "description"
+autodoc_class_signature = "mixed"
+
+# The default role for text marked up `like this`
+default_role = "any"
+
+# Tell sphinx what the primary language being documented is.
+primary_domain = "py"
+
+# Tell sphinx what the pygments highlight language should be.
+highlight_language = "python"
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_book_theme"
+html_static_path = ["_static"]
+
+html_theme_options = {
+    "github_url": "https://github.com/W-M-plasma-group/KN1DPy",
+}
+
+pygments_style = "sphinx"
+
+# -- Options for intersphinx extension ---------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#configuration
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy", None),
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ napoleon_type_aliases = {
 
 autodoc_default_options = {"ignore-module-all": True}
 autodoc_typehints = "description"
-autodoc_class_signature = "mixed"
+# autodoc_class_signature = "mixed"
 
 # The default role for text marked up `like this`
 default_role = "any"
@@ -78,4 +78,13 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
+}
+
+nitpick_ignore = {
+    ("py:class", "numpy.typing.ArrayLike"),
+    ("py:class", "numpy.typing.NDArray"),
+    ("py:class", "numpy.typing.Scalar"),
+}
+nitpick_ignore_regex = {
+    ("py:class", r".*_ScalarT"),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,8 @@ A comprehensive description of the algorithm can be found in this `PSFC report
    :maxdepth: 2
    :caption: User Guide:
 
+   kn1d_lite
+
 .. toctree::
    :maxdepth: 2
    :caption: Reference

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,30 @@
+.. KN1D documentation master file, created by
+   sphinx-quickstart on Fri Apr 17 10:35:42 2026.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+KN1D documentation
+==================
+
+KN1D is a 1D-space, 2D-velocity kinetic neutrals code developed by B. LaBombard
+(MIT PSFC). KN1DPy is a Python translation of the original IDL code (the
+original IDL version is also included in the ``IDL/`` directory of this
+repository).
+
+This translation was written by Nicholas Brown at William & Mary
+(njbrown@wm.edu), and is now maintained by Jamie Dunsmore at MIT
+(jduns@mit.edu).
+
+A comprehensive description of the algorithm can be found in this `PSFC report
+(LaBombard, 2001) <https://library.psfc.mit.edu/catalog/reports/2000/01rr/01rr003/01rr003_full.pdf>`_.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: User Guide:
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
+   API Reference <api>

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,19 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "KN1DPy"
 version = "0.1.0"
-requires-python = ">=3.7"
+requires-python = ">=3.11"
 
 dependencies = [
   "numpy>=1.21",
   "scipy>=1.7",
   "matplotlib>=3.5",
+]
+
+[dependency-groups]
+docs = [
+    "sphinx >=7,<10",
+    "sphinx_autodoc_typehints >= 1.19",
+    "sphinx-book-theme ~= 1.2.0",
 ]
 
 [tool.pixi.workspace]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ docs = [
     "sphinx >=7,<10",
     "sphinx_autodoc_typehints >= 1.19",
     "sphinx-book-theme ~= 1.2.0",
+    "myst_parser >= 0.14.0",
 ]
 
 [tool.pixi.workspace]


### PR DESCRIPTION
Adds a basic documentation structure, and fixes a bunch of issues in docstrings to improve formatting.

I've looked into automatically converting the PDF manual into plain text, but because PDFs are pretty much unstructured blobs, there isn't anything that can preserve the structure or equations. `pdftotext` does a reasonable job, but it will still need a great deal of manual editing to get it to look good.