### PR TITLE
Fixed rates for ly-alpha and ba-alpha calculations

### DIFF
--- a/KN1DPy/kn1d.py
+++ b/KN1DPy/kn1d.py
@@ -13,6 +13,7 @@ from .kinetic_h import KineticH
 from .kinetic_h2 import KineticH2
 from .kinetic_mesh import KineticMesh
 from .make_dvr_dvx import VSpace_Differentials
+from .rates.adas import adas_emissivity
 from .rates.johnson_hinnov.johnson_hinnov import Johnson_Hinnov
 from .utils import (
     convert_config_dict_to_dataclasses,
@@ -417,10 +418,18 @@ def kn1d(x, xlimiter, xsep, GaugeH2, mu, Ti, Te, n, vxi, LC, PipeDia,
 
     # --- Compute Lyman and Balmer Alpha ---
 
-    Lyman = jh.lyman_alpha(kh_mesh.ne, kh_mesh.Te, kh_results.nH, no_null=1)
-    Balmer = jh.balmer_alpha(kh_mesh.ne, kh_mesh.Te, kh_results.nH, no_null=1)
-    # Lyman = lyman_alpha(kh_mesh.ne, kh_mesh.Te, nH, jh_coefficients, no_null = 1) #NOTE Not Working Yet
-    # Balmer = balmer_alpha(kh_mesh.ne, kh_mesh.Te, nH, jh_coefficients, no_null = 1) #NOTE Not Working Yet
+    _use_adas_emissivity = (ion_rate_option != 'jh') and adas_emissivity.available
+    if _use_adas_emissivity:
+        Lyman = adas_emissivity.lyman_alpha(kh_mesh.ne, kh_mesh.Te, kh_results.nH)
+        Balmer = adas_emissivity.balmer_alpha(kh_mesh.ne, kh_mesh.Te, kh_results.nH)
+        emissivity_source = 'ADAS'
+        print(prompt, 'Lyman/Balmer emissivity: ADAS PEC')
+    else:
+        Lyman = jh.lyman_alpha(kh_mesh.ne, kh_mesh.Te, kh_results.nH, no_null=1)
+        Balmer = jh.balmer_alpha(kh_mesh.ne, kh_mesh.Te, kh_results.nH, no_null=1)
+        emissivity_source = 'JH'
+        if ion_rate_option != 'jh':
+            print(prompt, 'Warning: ADAS PEC data unavailable; Lyman/Balmer emissivity using Johnson-Hinnov')
 
 
     # --- Store Results ---

--- a/KN1DPy/rates/adas/adas_emissivity.py
+++ b/KN1DPy/rates/adas/adas_emissivity.py
@@ -1,0 +1,156 @@
+'''ADAS PEC-based Lyman-alpha and Balmer-alpha emissivity for atomic hydrogen.'''
+
+import re
+import urllib.request
+from pathlib import Path
+
+import numpy as np
+from scipy.interpolate import RectBivariateSpline
+
+ADAS_DIR = Path(__file__).resolve().parent
+
+_PEC_FILENAME = 'pec12_h_pju_h0.dat'
+_PEC_URL = 'https://open.adas.ac.uk/download/adf15/pec12][h/pec12][h_pju][h0.dat'
+
+# ISEL indices within pec12][h_pju][h0.dat
+_ISEL_LYA_EXC = 1    # Lyman-alpha 1215.2 A, excitation
+_ISEL_LYA_REC = 67   # Lyman-alpha 1215.2 A, recombination
+_ISEL_BAL_EXC = 3    # Balmer-alpha 6561.9 A, excitation
+_ISEL_BAL_REC = 69   # Balmer-alpha 6561.9 A, recombination
+
+# Photon energies (J): E = hc/lambda
+_E_LYA = 6.626e-34 * 2.998e8 / 1215.2e-10  # 1.635e-18 J  (10.2 eV)
+_E_BAL = 6.626e-34 * 2.998e8 / 6561.9e-10  # 3.027e-19 J  (1.89 eV)
+
+
+def _ensure_pec_data():
+    path = ADAS_DIR / _PEC_FILENAME
+    if not path.exists():
+        print(f'Downloading ADAS PEC data: {_PEC_FILENAME}')
+        urllib.request.urlretrieve(_PEC_URL, path)
+    return path
+
+
+def _read_adf15_block(lines, target_isel):
+    '''Extract ne, Te grid and PEC values for a given ISEL from ADF15 file lines.
+
+    Returns ne (m⁻³), Te (eV), pec (m³/s) with shape (n_ne, n_Te).
+    '''
+    header_idx = None
+    n_ne = n_Te = None
+    for i, line in enumerate(lines):
+        m = re.search(r'/ISEL\s*=\s*(\d+)', line, re.IGNORECASE)
+        if m and int(m.group(1)) == target_isel:
+            parts = line.split()
+            n_ne = int(parts[1])
+            n_Te = int(parts[2])
+            header_idx = i
+            break
+    if header_idx is None:
+        raise ValueError(f'ISEL={target_isel} not found in ADF15 file')
+
+    needed = n_ne + n_Te + n_ne * n_Te
+    vals = []
+    for line in lines[header_idx + 1:]:
+        if 'ISEL' in line.upper():
+            break  # reached the next block header
+        try:
+            vals.extend(float(x) for x in line.split())
+        except ValueError:
+            continue
+        if len(vals) >= needed:
+            break
+
+    ne_m3  = np.array(vals[:n_ne]) * 1e6                           # cm⁻³ → m⁻³
+    Te_eV  = np.array(vals[n_ne : n_ne + n_Te])
+    pec_m3 = np.array(vals[n_ne + n_Te : needed]).reshape(n_ne, n_Te) * 1e-6  # cm³/s → m³/s
+
+    return ne_m3, Te_eV, pec_m3
+
+
+def _make_pec_interp(ne, Te, pec):
+    '''Log-log RectBivariateSpline for PEC(ne, Te), clipped to grid bounds.
+
+    ne in m⁻³, Te in eV, pec in m³/s.  Returns a callable (ne_m3, Te_eV) → pec_m3.
+    '''
+    log_ne  = np.log10(ne)
+    log_Te  = np.log10(Te)
+    log_pec = np.log10(np.maximum(pec, 1e-99))
+    spl = RectBivariateSpline(log_ne, log_Te, log_pec, kx=3, ky=3)
+    ne_lo, ne_hi = log_ne[0], log_ne[-1]
+    Te_lo, Te_hi = log_Te[0], log_Te[-1]
+
+    def interp(ne_m3, Te_eV):
+        lne = np.clip(np.log10(np.asarray(ne_m3, dtype=float).ravel()), ne_lo, ne_hi)
+        lTe = np.clip(np.log10(np.asarray(Te_eV, dtype=float).ravel()), Te_lo, Te_hi)
+        return 10.0 ** np.array([float(spl(lne[i], lTe[i]).item(0))
+                                  for i in range(lne.size)])
+
+    return interp
+
+
+def _load_interpolators():
+    path = _ensure_pec_data()
+    with path.open() as f:
+        lines = f.readlines()
+
+    ne_e, Te_e, pec_lya_exc = _read_adf15_block(lines, _ISEL_LYA_EXC)
+    ne_r, Te_r, pec_lya_rec = _read_adf15_block(lines, _ISEL_LYA_REC)
+    _,    _,    pec_bal_exc = _read_adf15_block(lines, _ISEL_BAL_EXC)
+    _,    _,    pec_bal_rec = _read_adf15_block(lines, _ISEL_BAL_REC)
+
+    return (
+        _make_pec_interp(ne_e, Te_e, pec_lya_exc),
+        _make_pec_interp(ne_r, Te_r, pec_lya_rec),
+        _make_pec_interp(ne_e, Te_e, pec_bal_exc),
+        _make_pec_interp(ne_r, Te_r, pec_bal_rec),
+    )
+
+
+try:
+    _lya_exc, _lya_rec, _bal_exc, _bal_rec = _load_interpolators()
+    available = True
+except Exception:
+    available = False
+
+
+def lyman_alpha(ne, Te, n0, ni=None):
+    '''
+    Lyman-alpha emissivity (W/m³) using ADAS PEC coefficients.
+
+    emissivity = (ne * n0 * PEC_exc + ne * ni * PEC_rec) * E_photon
+
+    Parameters
+    ----------
+    ne : electron density (m⁻³)
+    Te : electron temperature (eV)
+    n0 : neutral hydrogen density (m⁻³)
+    ni : ion density (m⁻³); defaults to ne (quasi-neutral pure hydrogen)
+    '''
+    ne = np.asarray(ne, dtype=float).ravel()
+    Te = np.asarray(Te, dtype=float).ravel()
+    n0 = np.asarray(n0, dtype=float).ravel()
+    ni = ne if ni is None else np.asarray(ni, dtype=float).ravel()
+    photons = ne * (n0 * _lya_exc(ne, Te) + ni * _lya_rec(ne, Te))
+    return photons * _E_LYA
+
+
+def balmer_alpha(ne, Te, n0, ni=None):
+    '''
+    Balmer-alpha emissivity (W/m³) using ADAS PEC coefficients.
+
+    emissivity = (ne * n0 * PEC_exc + ne * ni * PEC_rec) * E_photon
+
+    Parameters
+    ----------
+    ne : electron density (m⁻³)
+    Te : electron temperature (eV)
+    n0 : neutral hydrogen density (m⁻³)
+    ni : ion density (m⁻³); defaults to ne (quasi-neutral pure hydrogen)
+    '''
+    ne = np.asarray(ne, dtype=float).ravel()
+    Te = np.asarray(Te, dtype=float).ravel()
+    n0 = np.asarray(n0, dtype=float).ravel()
+    ni = ne if ni is None else np.asarray(ni, dtype=float).ravel()
+    photons = ne * (n0 * _bal_exc(ne, Te) + ni * _bal_rec(ne, Te))
+    return photons * _E_BAL

--- a/KN1DPy/rates/johnson_hinnov/johnson_hinnov.py
+++ b/KN1DPy/rates/johnson_hinnov/johnson_hinnov.py
@@ -259,8 +259,10 @@ class Johnson_Hinnov:
         photons = np.full(Density.shape,1.0e32)
         r02 = self.jhr_coef(Density, Te, 0, 2, no_null=no_null)
         r12 = self.jhr_coef(Density, Te, 1, 2, no_null=no_null)
-        NHSaha1 = self.nh_saha(Density, Te, 1)
-        NHSaha2 = self.nh_saha(Density, Te, 2)
+        saha_density = np.clip(Density, np.exp(np.min(self.dknot)), np.exp(np.max(self.dknot))) if no_null else Density
+        saha_Te = np.clip(Te, np.exp(np.min(self.tknot)), np.exp(np.max(self.tknot))) if no_null else Te
+        NHSaha1 = self.nh_saha(saha_density, saha_Te, 1)
+        NHSaha2 = self.nh_saha(saha_density, saha_Te, 2)
 
         ok = np.where((N0 > 0) & (N0 < 1e32) & (r02 < 1.0e32) & (r12 < 1.0e32) & (NHSaha1 < 1.0e32) & (NHSaha2 < 1.0e32))[0]
 
@@ -308,8 +310,10 @@ class Johnson_Hinnov:
         photons = np.full(Density.shape,1.0e32)
         r03 = self.jhr_coef(Density, Te, 0, 3, no_null = no_null)
         r13 = self.jhr_coef(Density, Te, 1, 3, no_null = no_null)
-        NHSaha1 = self.nh_saha(Density, Te, 1)
-        NHSaha3 = self.nh_saha(Density, Te, 3)
+        saha_density = np.clip(Density, np.exp(np.min(self.dknot)), np.exp(np.max(self.dknot))) if no_null else Density
+        saha_Te = np.clip(Te, np.exp(np.min(self.tknot)), np.exp(np.max(self.tknot))) if no_null else Te
+        NHSaha1 = self.nh_saha(saha_density, saha_Te, 1)
+        NHSaha3 = self.nh_saha(saha_density, saha_Te, 3)
 
         ok = np.where((N0 > 0) & (N0 < 1e32) & (r03 < 1.0e32) & (r13 < 1.0e32) & (NHSaha1 < 1.0e32) & (NHSaha3 < 1.0e32))[0]
 


### PR DESCRIPTION
Fixed an issue with extrapolation of rate coefficients for the JH ly-alpha and Ba-alpha emissivity calculations. If rates for densities/temperatures outside the tabulated range are requested, the calculation is performed using the highest/lowest tabulated value now rather than extrapolating rate coefficients.

Also, have added in ADAS calculations rather than JH as the default for calculation for Ly-alpha and Ba-alpha emissivity. JH will now only be used if the user specifies JH rates for ionisation.